### PR TITLE
fix: fully disable plugins during reload

### DIFF
--- a/mechanicscore-core/src/main/kotlin/me/deecaad/core/MechanicsPlugin.kt
+++ b/mechanicscore-core/src/main/kotlin/me/deecaad/core/MechanicsPlugin.kt
@@ -119,6 +119,8 @@ open class MechanicsPlugin(
      * Attempts to reload this plugin and all its components.
      */
     open fun reload(): CompletableFuture<TaskImplementation<Void>> {
+        onDisable()
+        adventure0 = BukkitAudiences.create(this)
         return foliaScheduler.async().runNow { _ ->
             handleFiles()
         }.asFuture().thenCompose {


### PR DESCRIPTION
fix https://github.com/WeaponMechanics/WeaponMechanics/issues/527

Basically the reload plugin method was missing removing listeners, so when a reload happens we would end up with double. 