### PR TITLE
feat: ability to disable reloading commands when reloading plugin

### DIFF
--- a/mechanicscore-core/src/main/kotlin/me/deecaad/core/MechanicsPlugin.kt
+++ b/mechanicscore-core/src/main/kotlin/me/deecaad/core/MechanicsPlugin.kt
@@ -121,7 +121,7 @@ open class MechanicsPlugin(
             foliaScheduler.global().run { _ ->
                 handleConfigs().join()
                 handleListeners().join()
-                if (configuration.getBoolean("Reload.Register_CommandAPI_Commands", true)) {
+                if (configuration.getBoolean("Reload.Commands", true)) {
                     handleCommands().join()
                 }
             }.asFuture()

--- a/mechanicscore-core/src/main/kotlin/me/deecaad/core/MechanicsPlugin.kt
+++ b/mechanicscore-core/src/main/kotlin/me/deecaad/core/MechanicsPlugin.kt
@@ -121,7 +121,9 @@ open class MechanicsPlugin(
             foliaScheduler.global().run { _ ->
                 handleConfigs().join()
                 handleListeners().join()
-                handleCommands().join()
+                if (configuration.getBoolean("Reload.Register_CommandAPI_Commands", true)) {
+                    handleCommands().join()
+                }
             }.asFuture()
         }
     }

--- a/mechanicscore-core/src/main/resources/MechanicsCore/config.yml
+++ b/mechanicscore-core/src/main/resources/MechanicsCore/config.yml
@@ -10,9 +10,9 @@ Logger_Config:
   Max_Alerts_To_Show: 5
   Alert_Interval: 300  # 15 seconds * 20 ticks per second
 
-# If set to false, commands are not re-registered when this plugin reloads. Enable this if you experience issues with recipes reloading.
 Reload:
-  Register_CommandAPI_Commands: true
+  # Controls whether commands are re-registered on reload.
+  Commands: false
 
 # Turning on this feature will cause placeholder messages to use 3x the CPU.
 # If you want to use "placeholders inside of placeholders," like:

--- a/mechanicscore-core/src/main/resources/MechanicsCore/config.yml
+++ b/mechanicscore-core/src/main/resources/MechanicsCore/config.yml
@@ -10,6 +10,10 @@ Logger_Config:
   Max_Alerts_To_Show: 5
   Alert_Interval: 300  # 15 seconds * 20 ticks per second
 
+# If set to false, commands are not re-registered when this plugin reloads. Enable this if you experience issues with recipes reloading.
+Reload:
+  Register_CommandAPI_Commands: true
+
 # Turning on this feature will cause placeholder messages to use 3x the CPU.
 # If you want to use "placeholders inside of placeholders," like:
 # %changeoutput<_input:<ammo_left>_matcher:10_ifmatch:<ammo_left>_else:0<ammo_left>%,


### PR DESCRIPTION
Currently, reloading WeaponMechanics, or enabling WeaponMechanicsCosmetics on startup (which triggers a reload) results in the commands for both plugins being reloaded.

This is particularly problematic because it also results in registered recipes to be reloaded in versions 1.21.8+, and reloading recipes often causes duplication glitches and conflicts with other popular plugins (in our case Nexo).

To get around this issue, the `Reload.Commands` configuration option is introduced in this PR, which disables reloading commands when set to false. By default it is set to `true`, to maintain existing behaviour.

Adding the same configuration option to the configuration files for WeaponMechanics and WeaponMechanicsCosmetics will disable command reloading, as long as you have a MechanicsCore build with this feature.

```
Reload:
  # Controls whether commands are re-registered on reload.
  Commands: false
```